### PR TITLE
add general rule for Robot syntax errors

### DIFF
--- a/robocop/checkers/__init__.py
+++ b/robocop/checkers/__init__.py
@@ -12,6 +12,7 @@ Message ids:
 01: base
 02: documentation
 03: naming
+04: errors
 
 """
 

--- a/robocop/checkers/errors.py
+++ b/robocop/checkers/errors.py
@@ -1,0 +1,22 @@
+from robot.parsing.model.statements import Documentation, Comment
+from robocop.checkers import BaseChecker
+from robocop.messages import MessageSeverity
+
+MSGS = {
+    "0401": (
+        "parsing-error",
+        "Robot Framework syntax error: %s",
+        MessageSeverity.ERROR
+    )
+}
+
+
+def register(linter):
+    linter.register_checker(ParsingErrorChecker(linter))
+
+
+class ParsingErrorChecker(BaseChecker):
+    msgs = MSGS
+
+    def visit_Error(self, node):
+        self.report("parsing-error", node.error, node=node)


### PR DESCRIPTION
#25 

Robot Framework while parsing detect any syntax error as Error statement. We can use it to handle many code smells out of box. 

For example giving not existing section (*** Not Existing ***) lead to following message:
resource.robot:11:0 [E] 0401 Robot Framework syntax error: Unrecognized section header '*** Not Existing ***'. Valid sections: 'Settings', 'Variables', 'Test Cases', 'Tasks', 'Keywords' and 'Comments'.

Typo in [Return]:
resource.robot:9:0 [E] 0401 Robot Framework syntax error: Non-existing setting 'Retudrn'. Did you mean:
Return

Wrong variable declaration (^{var}):
robot:2:0 [E] 0401 Robot Framework syntax error: Invalid variable name '^{var}'.

Not existing keyword settings:
My External Keywords
    [Arguments]  ${arg1}=0  ${arg2}=0
    [Idontexist]  dd

robot:7:0 [E] 0401 Robot Framework syntax error: Non-existing setting 'Idontexist'.

And so on. 