### PR TITLE
configurable allowed file types

### DIFF
--- a/robocop/config/config.py
+++ b/robocop/config/config.py
@@ -15,6 +15,14 @@ class ParseCheckerConfig(argparse.Action):
         container.append(values)
 
 
+class ParseFileTypes(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        container = getattr(namespace, self.dest)
+        for filetype in values.split(','):
+            filetype = filetype if filetype.startswith('.') else '.' + filetype
+            container.add(filetype)
+
+
 class OpenOutputFile(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         file = open(values, 'w')  # TODO: raise custom exception if fail (ie dont have permissions)
@@ -31,6 +39,7 @@ class Config:
         self.paths = []
         self.include_patterns = list()
         self.exclude_patterns = list()
+        self.filetypes = {'.robot', '.resource'}
         self.output = None
 
     @staticmethod
@@ -54,8 +63,10 @@ class Config:
                             help="Configure checker with parameter value")
         parser.add_argument('-o', '--output', action=OpenOutputFile, default=self.output,
                             help='Path to output file')
+        parser.add_argument('--filetypes', action=ParseFileTypes, default=self.filetypes,
+                            help='Comma seperated list of file extensions to be scanned by Robocop')
         parser.add_argument('paths', metavar='paths', type=str, nargs='+',
-                            help='List of paths (files and directories) to be parsed by Robocop')
+                            help='List of paths (files and directories) to be scanned by Robocop')
         args = parser.parse_args()
         self.__dict__.update(**vars(args))
         self.translate_patterns()

--- a/robocop/run.py
+++ b/robocop/run.py
@@ -8,9 +8,6 @@ from robocop import reports
 from robocop.utils import DisablersFinder, FileType, FileTypeChecker
 
 
-SUPPORTED_FORMATS = ('.robot')
-
-
 class Robocop:
     def __init__(self):
         self.files = dict()
@@ -106,7 +103,7 @@ class Robocop:
         if not path.exists():
             raise StopIteration
         if path.is_file():
-            if Robocop.should_parse(path):
+            if self.should_parse(path):
                 yield path.absolute()
         elif path.is_dir():
             for file in path.iterdir():
@@ -114,9 +111,8 @@ class Robocop:
                     continue
                 yield from self.get_absolute_path(file, recursive)
 
-    @staticmethod
-    def should_parse(file):
-        return file.suffix in SUPPORTED_FORMATS
+    def should_parse(self, file):
+        return file.suffix and file.suffix in self.config.filetypes
 
     def any_rule_enabled(self, checker):
         for msg_name, msg in checker.messages.items():


### PR DESCRIPTION
Closes #11 
Also fixes two bugs:
Robocop was scanning files without extension (like .gitignore, .pabotsuitenames where filename is '.gitignore' and extension '')
Robocop was scanning only 'robot' file types (where in RF 3.2 default types are 'robot' and 'resource')