### PR TITLE
Add script for parsing pylama, update workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,10 +31,10 @@ jobs:
         pip install pytest
         pip install coverage
     - name: Code quality with pylama
-      run: pylama -o pylama.ini
+      run: python robocop/utils/pylama_parse.py
       if: always()
     - name: Run unit tests with coverage
-      run: 
+      run:
         coverage run -m pytest
       if: always()
     - name: Codecov

--- a/robocop/utils/pylama_parse.py
+++ b/robocop/utils/pylama_parse.py
@@ -1,0 +1,13 @@
+"""Run Pylama and parse output to find errors and exit process with proper return code"""
+import sys
+import subprocess
+
+output = subprocess.run('python -m pylama -o pylama.ini', stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd='.',
+                        shell=True)
+errors = [line.decode('utf-8') for line in output.stdout.splitlines() if '[E]' in str(line)]
+if errors:
+    print(f'Found {len(errors)} errors:')
+    for err in errors:
+        print(str(err))
+
+sys.exit(len(errors))


### PR DESCRIPTION
Adds script that runs pylama and parses its output by looking for errors. If no errors were found, it returns 0, otherwise it returns the number of reported errors. This will prevent `Unit tests` workflow to fail on other issues reported by pylama like warnings, refactors etc. 

Closes #78 