### PR TITLE
Add NumberOfReturnedArgsChecker checker

### DIFF
--- a/robocop/checkers/misc.py
+++ b/robocop/checkers/misc.py
@@ -4,6 +4,7 @@ Miscellaneous checkers
 from robot.parsing.model.statements import Return, KeywordCall
 from robocop.checkers import VisitorChecker
 from robocop.rules import RuleSeverity
+from robocop.utils import normalize_robot_name
 
 
 def register(linter):
@@ -15,15 +16,19 @@ class EarlyReturnChecker(VisitorChecker):
     rules = {
         "0901": (
             "keyword-after-return",
-            "Keyword call after [Return] statement",
+            "Keyword call after %s statement",
             RuleSeverity.ERROR
         )
     }
 
     def visit_Keyword(self, node):  # noqa
-        returned = False
+        returned = ''
         for child in node.body:
             if isinstance(child, Return):
-                returned = True
-            elif isinstance(child, KeywordCall) and returned:
-                self.report("keyword-after-return", node=child)
+                returned = '[Return]'
+            elif isinstance(child, KeywordCall):
+                if returned:
+                    self.report("keyword-after-return", returned, node=child)
+                if normalize_robot_name(child.keyword) == 'returnfromkeyword':
+                    returned = 'Return From Keyword'
+

--- a/robocop/reports.py
+++ b/robocop/reports.py
@@ -57,7 +57,7 @@ class RulesByIdReport(Report):
         if not message_counter_ordered:
             report += "No issues found\n"
             return report
-        longest_name = len(max(message_counter_ordered, key=itemgetter(0))[0])
+        longest_name = len(max(message_counter_ordered, key=itemgetter(0))[0]) + 3
         report += '\n'.join(f"{message:{longest_name}} : {count}" for message, count in message_counter_ordered)
         return report
 

--- a/robocop/utils/__init__.py
+++ b/robocop/utils/__init__.py
@@ -3,7 +3,7 @@ Parsing utils
 """
 from robocop.utils.disablers import DisablersFinder
 from robocop.utils.file_types import FileType, FileTypeChecker
-from robocop.utils.utils import modules_from_path, modules_from_paths, modules_in_current_dir
+from robocop.utils.utils import modules_from_path, modules_from_paths, modules_in_current_dir, normalize_robot_name
 
 
 __all__ = [
@@ -12,5 +12,6 @@ __all__ = [
     'FileTypeChecker',
     'modules_from_path',
     'modules_in_current_dir',
-    'modules_from_paths'
+    'modules_from_paths',
+    'normalize_robot_name'
 ]

--- a/robocop/utils/disablers.py
+++ b/robocop/utils/disablers.py
@@ -108,14 +108,14 @@ class DisablersFinder:
             self.rules[rule].lastblock = lineno
 
     def _end_block(self, rule, lineno):
+        if rule == 'all':
+            self._end_all_blocks(lineno)
         if rule not in self.rules:
             return
         if self.rules[rule].lastblock != -1:
             block = (self.rules[rule].lastblock, lineno)
             self.rules[rule].lastblock = -1
             self.rules[rule].blocks.append(block)
-        if rule == 'all':
-            self._end_all_blocks(lineno)
 
     def _end_all_blocks(self, lineno):
         for rule in self.rules:

--- a/robocop/utils/utils.py
+++ b/robocop/utils/utils.py
@@ -34,3 +34,7 @@ def modules_from_path(path, module_name=None, relative='.'):
                 continue
             if file.suffix == '.py' and file.stem != '__init__':
                 yield from modules_from_path(file, module_name, relative)
+
+
+def normalize_robot_name(name):
+    return name.replace(' ', '').replace('_', '').lower()

--- a/tests/loops.robot
+++ b/tests/loops.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Documentation  This is suite doc
+
+*** Test Cases ***
+This is test
+    [Documentation]  Test case doc
+    Log  1
+    FOR  ${index}  IN RANGE  0  10
+        This Is Keyword
+    END
+
+*** Keywords ***
+This Is Keyword
+    [Documentation]  Keyword doc
+    FOR  ${elem}  IN  elem1  elem2  elem3
+    ...  elem4
+        Log  ${elem}  # this is valid comment TODO:
+        not capitalized Keyword
+    END
+    [Return]
+    Return From_keyword
+    Log  smth

--- a/tests/returns.robot
+++ b/tests/returns.robot
@@ -1,0 +1,47 @@
+# robocop: disable=too-few-calls-in-keyword,0302
+*** Settings ***
+Documentation  This is suite doc
+
+*** Test Cases ***
+This is test
+    [Documentation]  Test case doc
+    ${arg1}  This Is Keyword
+
+*** Keywords ***
+This Is Keyword
+    [Documentation]  Keyword doc
+    [Return]
+
+This Is Keyword2
+    [Documentation]  Keyword doc
+    [Return]  ${arg}
+
+This Is Keyword3
+    [Documentation]  Keyword doc
+    [Return]  ${arg}  ${arg}  ${arg}  ${arg}  ${arg}
+
+This Is Keyword4
+    [Documentation]  Keyword doc
+    Return From Keyword
+
+This Is Keyword5
+    [Documentation]  Keyword doc
+    Return From Keyword  ${arg}  ${arg}
+
+This Is Keyword6
+    [Documentation]  Keyword doc
+    Return From Keyword  ${arg}  ${arg}  ${arg}  ${arg}  ${arg}
+
+This Is Keyword4
+    [Documentation]  Keyword doc
+    Return From Keyword If  ${True}
+
+This Is Keyword5
+    [Documentation]  Keyword doc
+    Return From Keyword If  ${True}  ${arg}  ${arg}
+
+This Is Keyword6
+    [Documentation]  Keyword doc
+    FOR  ${elem}  IN  smth  smth
+        Return From Keyword If  ${True}  ${arg}  ${arg}  ${arg}  ${arg}  ${arg}
+    END


### PR DESCRIPTION
Add NumberOfReturnedArgsChecker checker: closes #90 
Fixed #134 
Fixed issue where section was counted as empty if there was only special robocop: comment inside
Extened EarlyReturnChecker to count Return From Keyword keyword
Fixed bug with disablers where disabler for whole file only worked for 'all', not specific rule