### PR TITLE
Fix misaligned report print

### DIFF
--- a/robocop/reports.py
+++ b/robocop/reports.py
@@ -57,7 +57,7 @@ class RulesByIdReport(Report):
         if not message_counter_ordered:
             report += "No issues found\n"
             return report
-        longest_name = len(max(message_counter_ordered, key=itemgetter(0))[0]) + 3
+        longest_name = max(len(msg[0]) for msg in message_counter_ordered)
         report += '\n'.join(f"{message:{longest_name}} : {count}" for message, count in message_counter_ordered)
         return report
 


### PR DESCRIPTION
Lines were not aligned correctly:
```
Issues by ids:
W0902 (ineven-indent)    : 14
W0302 (not-capitalized-keyword-name) : 11
E0401 (parsing-error)    : 11
W0502 (too-few-calls-in-keyword) : 9
E0802 (duplicated-keyword) : 8
E0801 (duplicated-test-case) : 4
W0806 (duplicated-metadata) : 4
W0508 (empty-section)    : 4
```

Now:
```
Issues by ids:
W0902 (ineven-indent)                    : 14
W0302 (not-capitalized-keyword-name)     : 11
E0401 (parsing-error)                    : 11
W0502 (too-few-calls-in-keyword)         : 9
E0802 (duplicated-keyword)               : 8
E0801 (duplicated-test-case)             : 4
W0806 (duplicated-metadata)              : 4
W0508 (empty-section)                    : 4
I0606 (tag-already-set-in-force-tags)    : 4
```